### PR TITLE
Fix .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tinyspline"] 
-  path = tinyspline 
-  url = https://github.com/msteinbeck/tinyspline.git
+	path = tinyspline
+	url = https://github.com/msteinbeck/tinyspline.git
 [submodule "SQLiteCpp"]
 	path = SQLiteCpp
 	url = https://github.com/nidefawl/SQLiteCpp.git


### PR DESCRIPTION
The .gitmodules files has traling spaces that break some tooling, notably flatpak-builder.

While I submitted a fix for flatpak-builder, it would be nice to have this fixed:

https://github.com/flatpak/flatpak-builder/pull/551
